### PR TITLE
Fix routing regex and sanitize template data

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -60,22 +60,40 @@ function decodeBase64(str) {
   }
 }
 
+function escapeForScript(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/</g, '\\x3c')
+    .replace(/>/g, '\\x3e');
+}
+
 function renderTemplate(template, data) {
   let rendered = template;
   
+  const safeUid = escapeForScript(data.uid);
+  const safeUrl = escapeForScript(data.url);
+  const safeHostUrl = escapeForScript(data.a);
+  const safeIp = escapeForScript(data.ip);
+  const safeTime = escapeForScript(data.time);
+
   // Replace all placeholders with actual data
-  rendered = rendered.replace(/REPLACE_UID/g, data.uid || '');
-  rendered = rendered.replace(/REPLACE_URL/g, data.url || '');
-  rendered = rendered.replace(/REPLACE_HOST_URL/g, data.a || '');
-  rendered = rendered.replace(/REPLACE_IP/g, data.ip || '');
-  rendered = rendered.replace(/REPLACE_TIME/g, data.time || '');
+  rendered = rendered.replace(/REPLACE_UID/g, safeUid);
+  rendered = rendered.replace(/REPLACE_URL/g, safeUrl);
+  rendered = rendered.replace(/REPLACE_HOST_URL/g, safeHostUrl);
+  rendered = rendered.replace(/REPLACE_IP/g, safeIp);
+  rendered = rendered.replace(/REPLACE_TIME/g, safeTime);
   
   // Also handle the newer template format
-  rendered = rendered.replace(/\{\{UID\}\}/g, data.uid || '');
-  rendered = rendered.replace(/\{\{REDIRECT_URL\}\}/g, data.url || '');
-  rendered = rendered.replace(/\{\{HOST_URL\}\}/g, data.a || '');
-  rendered = rendered.replace(/\{\{IP\}\}/g, data.ip || '');
-  rendered = rendered.replace(/\{\{TIME\}\}/g, data.time || '');
+  rendered = rendered.replace(/\{\{UID\}\}/g, safeUid);
+  rendered = rendered.replace(/\{\{REDIRECT_URL\}\}/g, safeUrl);
+  rendered = rendered.replace(/\{\{HOST_URL\}\}/g, safeHostUrl);
+  rendered = rendered.replace(/\{\{IP\}\}/g, safeIp);
+  rendered = rendered.replace(/\{\{TIME\}\}/g, safeTime);
   
   return rendered;
 }
@@ -395,8 +413,8 @@ async function handleRequest(request, env) {
     }
 
     // Handle c/ and w/ paths (cloudflare and webview templates)
-    const cloudflareMatch = path.match(/^\/c\/([^/]+)\/([^/]+)/);
-    const webviewMatch = path.match(/^\/w\/([^/]+)\/([^/]+)/);
+    const cloudflareMatch = path.match(/^\/c\/([^/]+)\/(.+)/);
+    const webviewMatch = path.match(/^\/w\/([^/]+)\/(.+)/);
 
     if (cloudflareMatch) {
       const [, uid, uri] = cloudflareMatch;


### PR DESCRIPTION
Updated regex matchers for `/c/` and `/w/` routes to use `(.+)` instead of `([^/]+)` for the final group, ensuring base64-encoded strings with slashes are fully captured. Introduced an `escapeForScript` helper and applied it to all dynamic data injected via `renderTemplate` to prevent XSS vulnerabilities.

---
*PR created automatically by Jules for task [5324403764562089412](https://jules.google.com/task/5324403764562089412) started by @jbalagiya*