### PR TITLE
Fix routing regex for base64 payloads and prevent XSS in templates

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -60,22 +60,44 @@ function decodeBase64(str) {
   }
 }
 
+function escapeForScript(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/</g, '\\x3c')
+    .replace(/>/g, '\\x3e')
+    .replace(/&/g, '\\x26');
+}
+
 function renderTemplate(template, data) {
   let rendered = template;
   
+  // Escape data to prevent XSS
+  const escapedData = {
+    uid: escapeForScript(data.uid),
+    url: escapeForScript(data.url),
+    a: escapeForScript(data.a),
+    ip: escapeForScript(data.ip),
+    time: escapeForScript(data.time)
+  };
+
   // Replace all placeholders with actual data
-  rendered = rendered.replace(/REPLACE_UID/g, data.uid || '');
-  rendered = rendered.replace(/REPLACE_URL/g, data.url || '');
-  rendered = rendered.replace(/REPLACE_HOST_URL/g, data.a || '');
-  rendered = rendered.replace(/REPLACE_IP/g, data.ip || '');
-  rendered = rendered.replace(/REPLACE_TIME/g, data.time || '');
+  rendered = rendered.replace(/REPLACE_UID/g, escapedData.uid);
+  rendered = rendered.replace(/REPLACE_URL/g, escapedData.url);
+  rendered = rendered.replace(/REPLACE_HOST_URL/g, escapedData.a);
+  rendered = rendered.replace(/REPLACE_IP/g, escapedData.ip);
+  rendered = rendered.replace(/REPLACE_TIME/g, escapedData.time);
   
   // Also handle the newer template format
-  rendered = rendered.replace(/\{\{UID\}\}/g, data.uid || '');
-  rendered = rendered.replace(/\{\{REDIRECT_URL\}\}/g, data.url || '');
-  rendered = rendered.replace(/\{\{HOST_URL\}\}/g, data.a || '');
-  rendered = rendered.replace(/\{\{IP\}\}/g, data.ip || '');
-  rendered = rendered.replace(/\{\{TIME\}\}/g, data.time || '');
+  rendered = rendered.replace(/\{\{UID\}\}/g, escapedData.uid);
+  rendered = rendered.replace(/\{\{REDIRECT_URL\}\}/g, escapedData.url);
+  rendered = rendered.replace(/\{\{HOST_URL\}\}/g, escapedData.a);
+  rendered = rendered.replace(/\{\{IP\}\}/g, escapedData.ip);
+  rendered = rendered.replace(/\{\{TIME\}\}/g, escapedData.time);
   
   return rendered;
 }
@@ -395,8 +417,8 @@ async function handleRequest(request, env) {
     }
 
     // Handle c/ and w/ paths (cloudflare and webview templates)
-    const cloudflareMatch = path.match(/^\/c\/([^/]+)\/([^/]+)/);
-    const webviewMatch = path.match(/^\/w\/([^/]+)\/([^/]+)/);
+    const cloudflareMatch = path.match(/^\/c\/([^/]+)\/(.+)/);
+    const webviewMatch = path.match(/^\/w\/([^/]+)\/(.+)/);
 
     if (cloudflareMatch) {
       const [, uid, uri] = cloudflareMatch;


### PR DESCRIPTION
This PR fixes a bug in the routing logic where base64 payloads containing slashes were truncated. It also addresses potential XSS vulnerabilities by correctly escaping dynamically generated data before injecting it into script tags within the HTML templates.

---
*PR created automatically by Jules for task [10205947868226325545](https://jules.google.com/task/10205947868226325545) started by @jbalagiya*